### PR TITLE
Data structure fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+*.h5

--- a/jaxNRSur/DataLoader.py
+++ b/jaxNRSur/DataLoader.py
@@ -257,61 +257,26 @@ class NRSur7dq4DataLoader(eqx.Module):
     def read_coorb(self, file: dict, n_max: int) -> dict:
         result = {}
 
+        tags = [
+            "chiA_0",
+            "chiA_1",
+            "chiA_2",
+            "chiB_0",
+            "chiB_1",
+            "chiB_2",
+            "omega",
+            "omega_orb_0",
+            "omega_orb_1",
+        ]
+
         for i in range(len(self.t_ds)):
             result[f"ds_node_{i}"] = {}
 
-            result[f"ds_node_{i}"]["chiA_0_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["chiA_0_coefs"],
-                file[f"ds_node_{i}"]["chiA_0_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["chiA_1_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["chiA_1_coefs"],
-                file[f"ds_node_{i}"]["chiA_1_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["chiA_2_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["chiA_2_coefs"],
-                file[f"ds_node_{i}"]["chiA_2_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["chiB_0_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["chiB_0_coefs"],
-                file[f"ds_node_{i}"]["chiB_0_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["chiB_1_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["chiB_1_coefs"],
-                file[f"ds_node_{i}"]["chiB_1_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["chiB_2_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["chiB_2_coefs"],
-                file[f"ds_node_{i}"]["chiB_2_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["omega_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["omega_coefs"],
-                file[f"ds_node_{i}"]["omega_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["omega_orb_0_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["omega_orb_0_coefs"],
-                file[f"ds_node_{i}"]["omega_orb_0_bfOrders"],
-                n_max,
-            )
-
-            result[f"ds_node_{i}"]["omega_orb_1_predictors"] = polypredictor(
-                file[f"ds_node_{i}"]["omega_orb_1_coefs"],
-                file[f"ds_node_{i}"]["omega_orb_1_bfOrders"],
-                n_max,
-            )
+            for tag in tags:
+                result[f"ds_node_{i}"][f"{tag}_predictors"] = polypredictor(
+                    file[f"ds_node_{i}"][f"{tag}_coefs"],
+                    file[f"ds_node_{i}"][f"{tag}_bfOrders"],
+                    n_max,
+                )
 
         return result

--- a/jaxNRSur/PolyPredictor.py
+++ b/jaxNRSur/PolyPredictor.py
@@ -3,7 +3,7 @@ from jaxtyping import Array, Float, Int
 import equinox as eqx
 
 
-class polypredictor(eqx.Module):
+class PolyPredictor(eqx.Module):
     coefs: Float[Array, " n_sum"]
     bfOrders: Float[Array, " n_sum n_lambda"]
     n_max: Int
@@ -36,7 +36,7 @@ class polypredictor(eqx.Module):
                 jnp.power(X[jnp.newaxis, :, :], bfOrders[:, :, jnp.newaxis]),
                 axis=1,
             ),
-        )
+        )[0]
 
     # TODO think about padding the arrays to allow for vmapping on the function
     def __call__(


### PR DESCRIPTION
This patch fixes the data structure in data loader for NRSur7p.

The compilation time for this specific model was a bit long because of the for loop in evaluating the `PolyPredictor`. This PR made use of ensembling and scan to reduce the overhead and improve performance